### PR TITLE
Create Dog Years

### DIFF
--- a/Dog Years
+++ b/Dog Years
@@ -1,0 +1,24 @@
+// This constant is the user's age.
+const myAge = 75;
+
+// This indicates the dog years that have a different multiplier.
+let earlyYears = 2;
+earlyYears *= 10.5;
+
+// As we already counted the 2 early years of a dog's life, we can subtract this from the user's age.
+let laterYears = myAge - 2;
+
+// The later years of a dog's life converted to a human's life is like we're multiplying by 4.
+laterYears *= 4;
+
+// This joins the early years with the later years, resulting in the final age.
+let myAgeInDogYears = earlyYears + laterYears;
+
+// This saves the users' name into a variable with all the letters lowecased.
+const myName = 'Maria da Luz'.toLowerCase();
+
+console.log(`My name is ${myName}. I am ${myAge} years old in human years which is ${myAgeInDogYears} years old in dog years.`);
+
+
+
+


### PR DESCRIPTION
Dogs mature at a faster rate than human beings. We often say a dog’s age can be calculated in “dog years” to account for their growth compared to a human of the same age. In some ways we could say, time moves quickly for dogs — 8 years in a human’s life equates to 45 years in a dog’s life. How old would you be if you were a dog?

Here’s how you convert your age from “human years” to “dog years”:

The first two years of a dog’s life count as 10.5 dog years each.
Each year following equates to 4 dog years.
Before you start doing the math in your head, let a computer take care of it! Here I use JavaScript to convert your human age into dog years.